### PR TITLE
Fix can not send push notification from other platform services

### DIFF
--- a/ncmb_unity/Assets/Plugins/iOS/NCMBAppControllerPushAdditions.mm
+++ b/ncmb_unity/Assets/Plugins/iOS/NCMBAppControllerPushAdditions.mm
@@ -224,6 +224,7 @@ extern "C"
     const char * deviceTokenConstChar = [tokenId UTF8String];
     //Unityへデバイストークンを送り、UnityからmBaaS backendのinstallationクラスへ保存します
     notifyUnityWithClassName("NCMBManager", "onTokenReceived", deviceTokenConstChar);
+    UnitySendDeviceToken(deviceToken);
 }
 
 - (void)application:(UIApplication*)application didFailToRegisterForRemoteNotificationsWithError:(NSError*)error


### PR DESCRIPTION
Currently, this SDK is preventing to send push notification from other platform services.
This PR will be able to send push notification from other platform services.
