### PR TITLE
Rich view does not show when open rich notification from second times

### DIFF
--- a/ncmb_unity/Assets/Plugins/iOS/NCMBRichPushView.m
+++ b/ncmb_unity/Assets/Plugins/iOS/NCMBRichPushView.m
@@ -298,9 +298,11 @@ static NCMBRichPushView *rv;
     if ([urlStr isKindOfClass:[NSString class]]) {
         if (rv == nil){
             rv = [[NCMBRichPushView alloc]init];
-            UIInterfaceOrientation orientation = [[UIApplication sharedApplication]statusBarOrientation];
-            [rv appearWebView:orientation url:urlStr];
         }
+        // リッチビューが表示する
+        UIInterfaceOrientation orientation = [[UIApplication sharedApplication]statusBarOrientation];
+        [rv appearWebView:orientation url:urlStr];
+
         NSURL *url = [NSURL URLWithString:urlStr];
         NSURLRequest *req = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:5];
         [rv loadRequest:req];


### PR DESCRIPTION
## 概要(Summary)

- Fixed #77

## 動作確認手順(Step for Confirmation)

1. Put Test application in background mode
2. Send rich push notification to device
3. Tap on rich push → Open app and show rich view
4. Repeat step 1 → 3 for multiple times
→ Confirm that rich view show every time open rich push .