### PR TITLE
レスポンスシグネチャのチェック不具合対応

### DIFF
--- a/ncmb_unity/Assets/NCMB/Script/NCMBConnection.cs
+++ b/ncmb_unity/Assets/NCMB/Script/NCMBConnection.cs
@@ -361,21 +361,17 @@ namespace NCMB.Internal
 		/// セッショントークン有効稼働かの処理を行う
 		/// </summary>
 		internal void _checkResponseSignature (string code, string responseData, UnityWebRequest req, ref NCMBException error)
-		{
-			//レスポンスデータにエスケープシーケンスがあればアンエスケープし、mobile backend上と同一にします
-			var unescapeResponseData = responseData;
-			if (unescapeResponseData != null && unescapeResponseData != Regex.Unescape (unescapeResponseData)) {
-				unescapeResponseData = Regex.Unescape (unescapeResponseData);
-			}
-			String headerSring = req.GetResponseHeader(RESPONSE_SIGNATURE);
-			bool validation = NCMBSettings._responseValidationFlag;
-				
+		{		
 			//レスポンスシグネチャのチェック
 			if (NCMBSettings._responseValidationFlag && req.error == null && error == null && req.GetResponseHeader (RESPONSE_SIGNATURE) != null) {
 				string responseSignature = req.GetResponseHeader (RESPONSE_SIGNATURE).ToString ();
 				//データに絵文字があればUnicodeアンエスケープし、レスポンスシグネチャ計算用に対応する
 				//一般のエスケープ表記データ(ダブルクォーテーション..)はこの処理をしないのが正しいです
-				unescapeResponseData = NCMBUtility.unicodeUnescape(responseData);
+                var unescapeResponseData = responseData;
+
+                if(unescapeResponseData != null ){
+                    unescapeResponseData = NCMBUtility.unicodeUnescape(unescapeResponseData);
+                }
 				_signatureCheck (responseSignature, code, unescapeResponseData, req.downloadHandler.data, ref error);
 			}
 		}

--- a/ncmb_unity/Assets/NCMB/Script/NCMBConnection.cs
+++ b/ncmb_unity/Assets/NCMB/Script/NCMBConnection.cs
@@ -367,10 +367,15 @@ namespace NCMB.Internal
 			if (unescapeResponseData != null && unescapeResponseData != Regex.Unescape (unescapeResponseData)) {
 				unescapeResponseData = Regex.Unescape (unescapeResponseData);
 			}
+			String headerSring = req.GetResponseHeader(RESPONSE_SIGNATURE);
+			bool validation = NCMBSettings._responseValidationFlag;
 				
 			//レスポンスシグネチャのチェック
 			if (NCMBSettings._responseValidationFlag && req.error == null && error == null && req.GetResponseHeader (RESPONSE_SIGNATURE) != null) {
 				string responseSignature = req.GetResponseHeader (RESPONSE_SIGNATURE).ToString ();
+				//データに絵文字があればUnicodeアンエスケープし、レスポンスシグネチャ計算用に対応する
+				//一般のエスケープ表記データ(ダブルクォーテーション..)はこの処理をしないのが正しいです
+				unescapeResponseData = NCMBUtility.unicodeUnescape(responseData);
 				_signatureCheck (responseSignature, code, unescapeResponseData, req.downloadHandler.data, ref error);
 			}
 		}

--- a/ncmb_unity/Assets/NCMB/Script/NCMBUtility.cs
+++ b/ncmb_unity/Assets/NCMB/Script/NCMBUtility.cs
@@ -20,6 +20,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
+using System.Text.RegularExpressions;
+using System.Globalization;
 
 namespace NCMB.Internal
 {
@@ -324,6 +326,24 @@ namespace NCMB.Internal
 			}
 			return builder.ToString ();
 		}
+
+        //文字列中、4桁の16進数で表記されたUnicode文字(\uXXXX)のみをデコード
+        static internal string unicodeUnescape(string targetText)
+        {
+            string retval = Regex.Replace
+            (
+                targetText,
+                @"\\[Uu]([0-9A-Fa-f]{4})",
+                x =>
+                {
+                    ushort code = ushort.Parse(x.Groups[1].Value, NumberStyles.AllowHexSpecifier);
+                    return ((char)code).ToString();
+                }
+            );
+
+            return retval.ToString();
+        }
+
 	}
 	
 }

--- a/ncmb_unity/Assets/PlayModeTest/MockServerObject.cs
+++ b/ncmb_unity/Assets/PlayModeTest/MockServerObject.cs
@@ -17,6 +17,7 @@ public class MockServerObject
     //Response data
     public string responseJson = "";
     public int status = 404;
+    public bool responseSignature = false;
     
     public void validate()
     {

--- a/ncmb_unity/Assets/PlayModeTest/NCMBResponseSignatureTest.cs
+++ b/ncmb_unity/Assets/PlayModeTest/NCMBResponseSignatureTest.cs
@@ -1,0 +1,107 @@
+﻿using UnityEngine;
+using UnityEngine.TestTools;
+using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using NCMB;
+using System.Reflection;
+
+public class NCMBResponseSignatureTest
+{
+	[SetUp]
+	public void Init ()
+	{
+		NCMBTestSettings.Initialize ();
+	}
+
+    /**
+     * - 内容：ダブルクォーテーションが含まれた文字列が正しく保存出来るか確認する
+     * - 結果：値が正しく設定されていること
+     */
+    [UnityTest]
+    public IEnumerator DoubleQuoteInData()
+    {
+        // テストデータ検索
+        NCMBQuery<NCMBObject> query = new NCMBQuery<NCMBObject>("ABC");
+        query.WhereEqualTo("objectId", "eFyOet7e3rOVLD1Z");
+        query.FindAsync((List<NCMBObject> list, NCMBException e) => {
+            if (e == null)
+            {
+                Assert.AreEqual("\"value\"", list[0]["name"]);
+            }
+            else
+            {
+                Assert.Fail(e.ErrorMessage);
+            }
+            NCMBTestSettings.CallbackFlag = true;
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+
+        Assert.True(NCMBTestSettings.CallbackFlag);
+
+        yield return null;
+    }
+
+    /**
+     * - 内容：ダブルクォーテーションが含まれた文字列が正しく保存出来るか確認する
+     * - 結果：値が正しく設定されていること
+     */
+    [UnityTest]
+    public IEnumerator EmojiInData()
+    {
+        // テストデータ検索
+        NCMBQuery<NCMBObject> query = new NCMBQuery<NCMBObject>("ABC");
+        query.WhereEqualTo("objectId", "cuvYjyyLzRzXoqm5");
+        query.FindAsync((List<NCMBObject> list, NCMBException e) => {
+            if (e == null)
+            {
+                Assert.AreEqual("\uD83D\uDE03", list[0]["name"]);
+            }
+            else
+            {
+                Assert.Fail(e.ErrorMessage);
+            }
+            NCMBTestSettings.CallbackFlag = true;
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+
+        Assert.True(NCMBTestSettings.CallbackFlag);
+
+        yield return null;
+    }
+
+
+    /**
+     * - 内容：ダブルクォーテーションが含まれた文字列が正しく保存出来るか確認する
+     * - 結果：値が正しく設定されていること
+     */
+    [UnityTest]
+    public IEnumerator DoubleQuoteAndEmojiInData()
+    {
+        // テストデータ検索
+        NCMBQuery<NCMBObject> query = new NCMBQuery<NCMBObject>("ABC");
+        query.WhereEqualTo("objectId", "WvFit1DQ68qDC6E4");
+        query.FindAsync((List<NCMBObject> list, NCMBException e) => {
+            if (e == null)
+            {
+                Assert.AreEqual("\"test\"\uD83D\uDE03", list[0]["name"]);
+            }
+            else
+            {
+                Assert.Fail(e.ErrorMessage);
+            }
+            NCMBTestSettings.CallbackFlag = true;
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+
+        Assert.True(NCMBTestSettings.CallbackFlag);
+
+        yield return null;
+    }
+
+
+
+}

--- a/ncmb_unity/Assets/PlayModeTest/json/get_response_signature_with_double_quote.json
+++ b/ncmb_unity/Assets/PlayModeTest/json/get_response_signature_with_double_quote.json
@@ -1,0 +1,1 @@
+{"results":[{"objectId":"eFyOet7e3rOVLD1Z","createDate":"2018-03-12T07:19:28.607Z","updateDate":"2018-03-12T07:19:28.608Z","acl":{"*":{"read":true,"write":true}},"name":"\"value\""}]}

--- a/ncmb_unity/Assets/PlayModeTest/json/get_response_signature_with_double_quote_and_emoji.json
+++ b/ncmb_unity/Assets/PlayModeTest/json/get_response_signature_with_double_quote_and_emoji.json
@@ -1,0 +1,1 @@
+{"results":[{"objectId":"WvFit1DQ68qDC6E4","createDate":"2018-03-12T07:19:28.607Z","updateDate":"2018-03-12T07:19:28.608Z","acl":{"*":{"read":true,"write":true}},"name":"\"test\"😃"}]}

--- a/ncmb_unity/Assets/PlayModeTest/json/get_response_signature_with_emoji.json
+++ b/ncmb_unity/Assets/PlayModeTest/json/get_response_signature_with_emoji.json
@@ -1,0 +1,1 @@
+{"results":[{"objectId":"cuvYjyyLzRzXoqm5","createDate":"2018-03-12T07:19:28.607Z","updateDate":"2018-03-12T07:19:28.608Z","acl":{"*":{"read":true,"write":true}},"name":"😃"}]}

--- a/ncmb_unity/Assets/PlayModeTest/mbaas.yaml
+++ b/ncmb_unity/Assets/PlayModeTest/mbaas.yaml
@@ -278,6 +278,15 @@ response:
   file: /json/valid_script_object_test_response.json
 ---
 request:
+  url: 2015-09-01/script/testScriptObject_GET2.js
+  method: GET
+  query:
+    name: "[\"tarou1\",\"tarou2\"]"
+response:
+  status: 200
+  file: /json/valid_script_object_test_response.json
+---
+request:
   url: 2015-09-01/script/testScript_PUT.js
   method: PUT
   body:
@@ -347,6 +356,41 @@ request:
 response:
   status: 201
   file: /json/get_object_test_response.json
+# Response Signature Test
+# Add X-NCMB-Response-Signature field in response note to check response signature
+---
+request:
+  url: 2013-09-01/classes/ABC
+  method: GET
+  query:
+    where:
+        objectId: eFyOet7e3rOVLD1Z
+response:
+  status: 201
+  file: /json/get_response_signature_with_double_quote.json
+  X-NCMB-Response-Signature: Signature_will_be_caculated_on_runtime
+---
+request:
+  url: 2013-09-01/classes/ABC
+  method: GET
+  query:
+    where:
+        objectId: cuvYjyyLzRzXoqm5
+response:
+  status: 201
+  file: /json/get_response_signature_with_emoji.json
+  X-NCMB-Response-Signature: Signature_will_be_caculated_on_runtime
+---
+request:
+  url: 2013-09-01/classes/ABC
+  method: GET
+  query:
+    where:
+        objectId: WvFit1DQ68qDC6E4
+response:
+  status: 201
+  file: /json/get_response_signature_with_double_quote_and_emoji.json
+  X-NCMB-Response-Signature: Signature_will_be_caculated_on_runtime
 # Use NCMBFileTest
 ---
 request:


### PR DESCRIPTION
## 概要(Summary)

- Fixed #38

## 動作確認手順(Step for Confirmation)
■現象
・事前環境設定：Response Validationにチェックをする
・値にダブルクォーテーションが入っている場合 - 検索失敗 -> レスポンスシグネチャチェックにNGになるのを改善

■対応
・パターン１ : ダブルクォーテーションなどエスケープがあるデータ
・パターン２ : 絵文字(4桁の16進数で表記されたUnicode文字)があるデータ
・パターン３ : 絵文字とダブルクォーテーションが混雑するデータ

■テスト実施もnode app.jsで全ＯＫになりました。

Run the unit test.
