### PR TITLE
Fix: LogoutAsync() and LoginAsync throw exception when the token has expired.

### DIFF
--- a/ncmb_unity/Assets/NCMB/Script/NCMBUser.cs
+++ b/ncmb_unity/Assets/NCMB/Script/NCMBUser.cs
@@ -469,7 +469,7 @@ namespace  NCMB
 			//ログを確認（通信前）
 			NCMBDebug.Log("【url】:" + url + Environment.NewLine + "【type】:" + type);
 			//通信処理
-			NCMBConnection con = new NCMBConnection(url, type, null, NCMBUser._getCurrentSessionToken());
+            NCMBConnection con = new NCMBConnection(url, type, null, null);
 			con.Connect(delegate (int statusCode, string responseData, NCMBException error)
 			{
 				try
@@ -638,7 +638,12 @@ namespace  NCMB
 					error = new NCMBException (e);
 				}
 				if (callback != null) {
-					callback (error);
+                    //If the system get ErrorCode is E401001 when LogOutAsync, We will return null.
+                    if (error != null && NCMBException.INCORRECT_HEADER.Equals(error.ErrorCode)) {
+                        callback(null);
+                    } else {
+                        callback(error);
+                    }
 				}
 				return;
 			});	

--- a/ncmb_unity/Assets/PlayModeTest/NCMBUserTest.cs
+++ b/ncmb_unity/Assets/PlayModeTest/NCMBUserTest.cs
@@ -549,4 +549,46 @@ public class NCMBUserTest
         Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
         Assert.True(NCMBTestSettings.CallbackFlag);
     }
+
+    /**
+    * - 内容：LogInAsyncExpiredToken
+    * - 結果：各パラメータが正しく取得できること
+    */
+    [UnityTest]
+    public IEnumerator LogInAsyncExpiredToken()
+    {
+        NCMBTestSettings.CallbackFlag = false;
+        // テストデータ作成
+        NCMBUser.LogInAsync("expireToken", "expireToken", (e) => {
+            NCMBTestSettings.CallbackFlag = true;
+        });
+        yield return NCMBTestSettings.AwaitAsync();
+
+        NCMBUser.CurrentUser.SessionToken = "dummySessionTokenInvalid";
+
+        NCMBTestSettings.CallbackFlag = false;
+        NCMBUser.LogInAsync("expireToken", "expireToken", (e) => {
+            Assert.Null(e);
+            NCMBTestSettings.CallbackFlag = true;
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        // 登録成功の確認
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("expireToken", NCMBUser.CurrentUser.UserName);
+        Assert.True(NCMBTestSettings.CallbackFlag);
+    }
+
+    [UnityTest]
+    public IEnumerator LogOutAsyncExpiredToken()
+    { 
+        NCMBTestSettings.CallbackFlag = false;
+        NCMBUser.LogOutAsync((e) =>
+        {
+            Assert.Null(e);
+            NCMBTestSettings.CallbackFlag = true;
+        });
+        yield return NCMBTestSettings.AwaitAsync();
+        Assert.True(NCMBTestSettings.CallbackFlag);
+    }
 }

--- a/ncmb_unity/Assets/PlayModeTest/json/login_invalid_token_response.json
+++ b/ncmb_unity/Assets/PlayModeTest/json/login_invalid_token_response.json
@@ -1,0 +1,1 @@
+{"objectId":"dummyObjectId","userName":"expireToken","mailAddress":"sample@example.com","mailAddressConfirm":true,"sessionToken":"dummySessionToken","createDate":"2017-10-03T07:58:47.193Z","updateDate":"2017-11-27T09:01:29.687Z","authData":null}

--- a/ncmb_unity/Assets/PlayModeTest/mbaas.yaml
+++ b/ncmb_unity/Assets/PlayModeTest/mbaas.yaml
@@ -21,12 +21,31 @@ response:
   file: /json/login_response.json
 ---
 request:
+  url: 2013-09-01/login
+  method: GET
+  query:
+    password: expireToken
+    userName: expireToken
+response:
+  status: 200
+  file: /json/login_invalid_token_response.json
+---
+request:
   url: 2013-09-01/logout
   method: GET
   body:
     Content-Type: application/json
 response:
   status: 200
+  file: /json/logout_script_response.json
+---
+request:
+  url: 2013-09-01/logout
+  method: GET
+  body:
+    Content-Type: application/json
+response:
+  status: 401
   file: /json/logout_script_response.json
 ---
 request:


### PR DESCRIPTION
SDKの改善にご協力いただきありがとうございます。  
(Thank you for your support our SDK.)

プルリクエストを作成する場合は、developをターゲットにしてください。  
(Please select target branch to "develop" branch.)

可能な限り、修正時にはテストコードまたは動作確認手順を追加してください。  
(Please include test code or describe confirmation steps as possible.)
The code confirm for LogoutAsync() test by manual:
```
void LogOut()
    {
        try
        {
            NCMBUser.LogOutAsync((NCMBException e) => {
                if (e != null)
                {
                    Debug.Log("LogOut: " + e.ErrorMessage);
                }
                else
                {
                    Debug.Log("LogOut OK");
                }
            });
        }
        catch (NCMBException e)
        {
            outPut.text = "Error: " + e.ErrorMessage;
            Debug.Log("Error" + e.ErrorMessage);
        }
    }
```
The code confirm for LoginAsync() test by manual:
   ```
 void LoginUser(string txtName, string txtPass)
    {
        NCMBUser.LogInAsync(txtName, txtPass, (NCMBException e) => {
            if (e != null)
            {
                Debug.Log("Error: " + e.ErrorMessage);
            }
            else
            {
                outPut.text = "OK";
                Debug.Log("OK");
            }
        });
    }
```

## 概要(Summary)

- Fixed:  loginAsync() and logoutAsync() Throw exception when the token has expired.

## 動作確認手順(Step for Confirmation)
Implement the app and Manual test.
Run the unit test.
