### PR TITLE
4.0.1 - Error when logged in user is updated more than once

### DIFF
--- a/ncmb_unity/Assets/NCMB/Script/NCMBUser.cs
+++ b/ncmb_unity/Assets/NCMB/Script/NCMBUser.cs
@@ -225,6 +225,7 @@ namespace  NCMB
 				if (_currentUser != null && _currentUser.ObjectId.Equals(this.ObjectId)) {
 					this.SessionToken = _currentUser.SessionToken;
 					_saveCurrentUser((NCMBUser)this);
+					this._currentOperations.Remove("sessionToken");
 				}
 			}
 		}
@@ -233,7 +234,9 @@ namespace  NCMB
 		internal override void _afterDelete (NCMBException error)
 		{
 			if (error == null) {
-				_logOutEvent ();
+				if ((_currentUser != null) && (_currentUser.ObjectId == this.ObjectId)) {
+					_logOutEvent ();
+				}
 			}
 		}
 

--- a/ncmb_unity/Assets/PlayModeTest/NCMBObjectTest.cs
+++ b/ncmb_unity/Assets/PlayModeTest/NCMBObjectTest.cs
@@ -68,5 +68,103 @@ public class NCMBObjectTest
 	}
 
 
+    [UnityTest]
+    public IEnumerator FetchObjectAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) => {
+            Assert.Null(e);
+            NCMBObject obj = new NCMBObject("TestClass");
+            obj.ObjectId = "testclassDummyObjectId";
+            obj.FetchAsync((NCMBException ex) => {
+                Assert.Null(ex);
+
+                NCMBTestSettings.CallbackFlag = true;
+            });
+
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("sample@example.com", NCMBUser.CurrentUser.Email);
+    }
+
+    [UnityTest]
+    public IEnumerator AddObjectAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) => {
+            Assert.Null(e);
+            NCMBObject obj = new NCMBObject("TestClass");
+            obj.Add("key", "value");
+            obj.SaveAsync((NCMBException ex) => {
+                Assert.Null(ex);
+
+                NCMBTestSettings.CallbackFlag = true;
+            });
+
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("sample@example.com", NCMBUser.CurrentUser.Email);
+    }
+
+    [UnityTest]
+    public IEnumerator UpdateObjectAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) => {
+            Assert.Null(e);
+            NCMBObject obj = new NCMBObject("TestClass");
+            obj.ObjectId = "dummyObjectId";
+            obj.Add("key", "newValue");
+            obj.SaveAsync((NCMBException ex) => {
+                Assert.Null(ex);
+
+                NCMBTestSettings.CallbackFlag = true;
+            });
+
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("sample@example.com", NCMBUser.CurrentUser.Email);
+    }
+
+    [UnityTest]
+    public IEnumerator DeleteObjectAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) => {
+            Assert.Null(e);
+            NCMBObject obj = new NCMBObject("TestClass");
+            obj.ObjectId = "dummyObjectId";
+            obj.DeleteAsync((NCMBException ex) => {
+                Assert.Null(ex);
+
+                NCMBTestSettings.CallbackFlag = true;
+            });
+
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("sample@example.com", NCMBUser.CurrentUser.Email);
+    }
+
+
 
 }

--- a/ncmb_unity/Assets/PlayModeTest/NCMBUserTest.cs
+++ b/ncmb_unity/Assets/PlayModeTest/NCMBUserTest.cs
@@ -549,4 +549,345 @@ public class NCMBUserTest
         Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
         Assert.True(NCMBTestSettings.CallbackFlag);
     }
+
+    [UnityTest]
+    public IEnumerator FetchCurrentUserAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) => {
+            Assert.Null(e);
+
+            NCMBUser.CurrentUser.FetchAsync((NCMBException ex) =>
+            {
+                Assert.Null(ex);
+                NCMBTestSettings.CallbackFlag = true;
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("sample@example.com", NCMBUser.CurrentUser.Email);
+    }
+
+    [UnityTest]
+    public IEnumerator UpdateCurrentUserAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) =>
+        {
+            Assert.Null(e);
+
+            NCMBUser.CurrentUser.UserName = "newUserName";
+
+            NCMBUser.CurrentUser.SaveAsync((NCMBException ex) =>
+            {
+                Assert.Null(ex);
+
+                NCMBTestSettings.CallbackFlag = true;
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("newUserName", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("sample@example.com", NCMBUser.CurrentUser.Email);
+    }
+
+    [UnityTest]
+    public IEnumerator UpdateCurrentUserTwoTimesAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) =>
+        {
+            Assert.Null(e);
+
+            NCMBUser.CurrentUser.UserName = "newUserName";
+
+            NCMBUser.CurrentUser.SaveAsync((NCMBException ex1) =>
+            {
+                Assert.Null(ex1);
+
+                NCMBUser.CurrentUser.UserName = "newUserName";
+                NCMBUser.CurrentUser.SaveAsync((NCMBException ex2) =>
+                {
+                    Assert.Null(ex2);
+
+                    NCMBTestSettings.CallbackFlag = true;
+                });
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("newUserName", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("sample@example.com", NCMBUser.CurrentUser.Email);
+        Assert.AreEqual(0, NCMBUser.CurrentUser._currentOperations.Count);
+    }
+
+    [UnityTest]
+    public IEnumerator SignUpUseCurrentUserAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) =>
+        {
+            Assert.Null(e);
+
+            NCMBUser.CurrentUser.ObjectId = null;
+            NCMBUser.CurrentUser.UserName = "testuser";
+            NCMBUser.CurrentUser.Password = "password";
+
+            // 会員登録
+            NCMBUser.CurrentUser.SignUpAsync((NCMBException ex) => {
+                Assert.Null(ex);
+                NCMBTestSettings.CallbackFlag = true;
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("testuser", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+    }
+
+    [UnityTest]
+    public IEnumerator DeleteUseCurrentUserAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) =>
+        {
+            Assert.Null(e);
+
+            NCMBUser.CurrentUser.DeleteAsync((NCMBException ex) => {
+                Assert.Null(ex);
+                NCMBTestSettings.CallbackFlag = true;
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.IsNull(NCMBUser.CurrentUser);
+    }
+
+    [UnityTest]
+    public IEnumerator FetchOtherUserAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) => {
+            Assert.Null(e);
+
+            NCMBUser user = new NCMBUser();
+            user.ObjectId = "anotherObjectId";
+            user.FetchAsync((NCMBException ex) =>
+            {
+                Assert.Null(ex);
+                NCMBTestSettings.CallbackFlag = true;
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+    }
+
+    [UnityTest]
+    public IEnumerator UpdateOtherUserAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) =>
+        {
+            Assert.Null(e);
+
+            NCMBUser user = new NCMBUser();
+            user.ObjectId = "anotherObjectId";
+            user.UserName = "newUserName";
+            user.SaveAsync((NCMBException ex) =>
+            {
+                Assert.Null(ex);
+
+                NCMBTestSettings.CallbackFlag = true;
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        // 登録成功の確認
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.IsNotNull(NCMBUser.CurrentUser);
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+    }
+
+    [UnityTest]
+    public IEnumerator DeleteOtherUserAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) =>
+        {
+            Assert.Null(e);
+
+            NCMBUser user = new NCMBUser();
+            user.ObjectId = "anotherObjectId";
+            user.DeleteAsync((NCMBException ex) => {
+                Assert.Null(ex);
+                NCMBTestSettings.CallbackFlag = true;
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+
+        Assert.IsNotNull(NCMBUser.CurrentUser);
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+    }
+
+    [UnityTest]
+    public IEnumerator SignUpOtherUserAfterLogin()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e) =>
+        {
+            Assert.Null(e);
+
+            NCMBUser user = new NCMBUser();
+            user.UserName = "testuser";
+            user.Password = "password";
+
+            // 会員登録
+            user.SignUpAsync((NCMBException ex) => {
+                Assert.Null(ex);
+                NCMBTestSettings.CallbackFlag = true;
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+    }
+
+    [UnityTest]
+    public IEnumerator LoginLogoutFetchUser()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e1) =>
+        {
+            Assert.Null(e1);
+            NCMBTestSettings.CallbackFlag = true;
+            NCMBUser.LogOutAsync();
+            NCMBUser.LogInAsync("tarou", "tarou", (e2) =>
+            {
+                Assert.Null(e2);
+                NCMBUser user = new NCMBUser();
+                user.ObjectId = "anotherObjectId";
+                user.FetchAsync((NCMBException e3) =>
+                {
+                    Assert.Null(e3);
+                    NCMBTestSettings.CallbackFlag = true;
+                });
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+    }
+
+    [UnityTest]
+    public IEnumerator LoginLogoutUpdateUser()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e1) =>
+        {
+            Assert.Null(e1);
+            NCMBTestSettings.CallbackFlag = true;
+            NCMBUser.LogOutAsync();
+            NCMBUser.LogInAsync("tarou", "tarou", (e2) =>
+            {
+                Assert.Null(e2);
+                NCMBUser user = new NCMBUser();
+                user.ObjectId = "anotherObjectId";
+                user.UserName = "newUserName";
+                user.SaveAsync((NCMBException e3) =>
+                {
+                    Assert.Null(e3);
+
+                    NCMBTestSettings.CallbackFlag = true;
+                });
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+    }
+
+    [UnityTest]
+    public IEnumerator LoginLogoutAddUser()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e1) =>
+        {
+            Assert.Null(e1);
+            NCMBTestSettings.CallbackFlag = true;
+            NCMBUser.LogOutAsync();
+            NCMBUser.LogInAsync("tarou", "tarou", (e2) =>
+            {
+                Assert.Null(e2);
+                NCMBUser user = new NCMBUser();
+                user.UserName = "testuser";
+                user.Password = "password";
+                user.SignUpAsync((NCMBException e3) => {
+                    Assert.Null(e3);
+                    NCMBTestSettings.CallbackFlag = true;
+                });
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+    }
+
+    [UnityTest]
+    public IEnumerator LoginLogoutDeleteUser()
+    {
+        // テストデータ作成
+        NCMBUser.LogInAsync("tarou", "tarou", (e1) =>
+        {
+            Assert.Null(e1);
+            NCMBTestSettings.CallbackFlag = true;
+            NCMBUser.LogOutAsync();
+            NCMBUser.LogInAsync("tarou", "tarou", (e2) =>
+            {
+                Assert.Null(e2);
+                NCMBUser user = new NCMBUser();
+                user.ObjectId = "anotherObjectId";
+                user.DeleteAsync((NCMBException e3) => {
+                    Assert.Null(e3);
+                    NCMBTestSettings.CallbackFlag = true;
+                });
+            });
+        });
+
+        yield return NCMBTestSettings.AwaitAsync();
+        Assert.True(NCMBTestSettings.CallbackFlag);
+        Assert.AreEqual("dummySessionToken", NCMBUser._getCurrentSessionToken());
+        Assert.AreEqual("tarou", NCMBUser.CurrentUser.UserName);
+    }
 }

--- a/ncmb_unity/Assets/PlayModeTest/json/fetch_other_user_response.json
+++ b/ncmb_unity/Assets/PlayModeTest/json/fetch_other_user_response.json
@@ -1,0 +1,1 @@
+{"objectId":"anotherObjectId","userName":"testuser","mailAddress":"sample@example.com","mailAddressConfirm":true,"sessionToken":"dummySessionToken","createDate":"2017-10-03T07:58:47.193Z","updateDate":"2017-11-27T09:01:29.687Z","authData":null}

--- a/ncmb_unity/Assets/PlayModeTest/json/fetch_user_response.json
+++ b/ncmb_unity/Assets/PlayModeTest/json/fetch_user_response.json
@@ -1,0 +1,1 @@
+{"objectId":"dummyObjectId","userName":"tarou","mailAddress":"sample@example.com","mailAddressConfirm":true,"sessionToken":"dummySessionToken","createDate":"2017-10-03T07:58:47.193Z","updateDate":"2017-11-27T09:01:29.687Z","authData":null}

--- a/ncmb_unity/Assets/PlayModeTest/json/get_testclass_object_response.json
+++ b/ncmb_unity/Assets/PlayModeTest/json/get_testclass_object_response.json
@@ -1,0 +1,15 @@
+{
+  "results": [
+    {
+      "objectId": "testclassDummyObjectId",
+      "key": "\"test\"",
+      "createDate": "2017-08-11T03:39:23.383Z",
+      "updateDate": "2017-08-11T03:42:06.352Z",
+      "acl": {
+        "*": {
+          "read": true,
+        }
+      }
+    }
+  ]
+}

--- a/ncmb_unity/Assets/PlayModeTest/json/valid_post_registerTestUser_response.json
+++ b/ncmb_unity/Assets/PlayModeTest/json/valid_post_registerTestUser_response.json
@@ -1,0 +1,7 @@
+{
+  "createDate":"2017-01-01T00:00:00.000Z",
+  "objectId":"anotherObjectId",
+  "userName":"testuser",
+  "authData":null,
+  "sessionToken":"dummySessionToken"
+}

--- a/ncmb_unity/Assets/PlayModeTest/mbaas.yaml
+++ b/ncmb_unity/Assets/PlayModeTest/mbaas.yaml
@@ -11,6 +11,13 @@ response:
   file: /json/login_response.json
 ---
 request:
+  url: 2013-09-01/users/dummyObjectId
+  method: GET
+response:
+  status: 200
+  file: /json/fetch_user_response.json
+---
+request:
   url: 2013-09-01/login
   method: GET
   query:
@@ -233,6 +240,38 @@ response:
 ---
 request:
   url: 2013-09-01/users/dummyObjectId
+  method: PUT
+  body:
+    userName: newUserName
+response:
+  status: 200
+  file: /json/valid_put_response.json
+---
+request:
+  url: 2013-09-01/users/anotherObjectId
+  method: GET
+response:
+  status: 200
+  file: /json/fetch_other_user_response.json
+---
+request:
+  url: 2013-09-01/users/anotherObjectId
+  method: PUT
+  body:
+    userName: newUserName
+response:
+  status: 200
+  file: /json/valid_put_response.json
+---
+request:
+  url: 2013-09-01/users/dummyObjectId
+  method: DELETE
+response:
+  status: 200
+  file: /json/valid_empty_script_response.json
+---
+request:
+  url: 2013-09-01/users/anotherObjectId
   method: DELETE
 response:
   status: 200
@@ -257,6 +296,23 @@ request:
 response:
   status: 201
   file: /json/valid_post_registerUser_response.json
+---
+request:
+  url: 2013-09-01/users
+  method: POST
+  body:
+    userName: "testuser"
+    password: "password"
+response:
+  status: 201
+  file: /json/valid_post_registerTestUser_response.json
+---
+request:
+  url: 2013-09-01/users/dummyObjectId
+  method: DELETE
+response:
+  status: 200
+  file: /json/post_success_response.json
 # Use NCMBUserTest
 ---
 request:
@@ -346,6 +402,38 @@ request:
 response:
   status: 201
   file: /json/post_success_response.json
+---
+request:
+  url: 2013-09-01/classes/TestClass/testclassDummyObjectId
+  method: GET
+response:
+  status: 200
+  file: /json/get_testclass_object_response.json
+---
+request:
+  url: 2013-09-01/classes/TestClass
+  method: POST
+  body:
+    key: value
+response:
+  status: 201
+  file: /json/post_success_response.json
+---
+request:
+  url: 2013-09-01/classes/TestClass/dummyObjectId
+  method: PUT
+  body:
+      key: newValue
+response:
+  status: 200
+  file: /json/get_object_test_response.json
+---
+request:
+  url: 2013-09-01/classes/TestClass/dummyObjectId
+  method: DELETE
+response:
+  status: 200
+  file: /json/valid_empty_script_response.json
 ---
 request:
   url: 2013-09-01/classes/TestClass


### PR DESCRIPTION
## 概要(Summary)

- Fixed #149, #158, #143

## 動作確認手順(Step for Confirmation)

- Run the unit test
- Confirm operation:

1. Prepare the environment according to the “Quick Start” procedure.
2. Attach the following script to the NCMBSettings object and execute it.

```
using NCMB;
using NCMB.Tasks;
using UnityEngine;

public class NCMBTest : MonoBehaviour {
    private async void Start() {

        await NCMBUser.LogOutTaskAsync();

        NCMBUser user = new NCMBUser();

        user.UserName = "Yamada Tarou";
        user.Password = "password";
        user.Add("phone", "987-654-3210");

        await user.SignUpTaskAsync();

        //987-654-3210と表示される
        Debug.Log(user["phone"]);

        NCMBUser currentUser = await    NCMBUser.LogInTaskAsync("Yamada Tarou", "password");

        currentUser["phone"] = "987-654-0123";

        currentUser = await currentUser.SaveTaskAsync();

        //987-654-0123と表示される
        Debug.Log(currentUser["phone"]);

        currentUser["phone"] = "987-654-2222";

        //エラーが発生しない
        //StatusCode:200
        //ResponseData:
        currentUser = await currentUser.SaveTaskAsync();

        Debug.Log(currentUser["phone"]);
    }
}
```