### PR TITLE
isNetworkError and isHttpError are now deprecated

### DIFF
--- a/ncmb_unity/Assets/NCMB/Script/NCMBConnection.cs
+++ b/ncmb_unity/Assets/NCMB/Script/NCMBConnection.cs
@@ -413,11 +413,15 @@ namespace NCMB.Internal
 				// タイムアウト
 				error.ErrorCode = "408";
 				error.ErrorMessage = "Request Timeout.";
+			#if UNITY_2020_2_OR_NEWER
+			} else if (req.result == UnityWebRequest.Result.ConnectionError) {
+			#else
 				#if UNITY_2017_1_OR_NEWER
 			} else if (req.isNetworkError) {
 				#else
 			} else if (req.isError) {
 				#endif
+			#endif
 				// 通信エラー
 				error = new NCMBException ();
 				error.ErrorCode = req.responseCode.ToString ();


### PR DESCRIPTION
## 概要(Summary)

Web: Obsoleted: UnityWebRequest: isNetworkError and isHttpError are now deprecated from Unity 2020.2.0

- Fixed https://github.com/NIFCLOUD-mbaas/UserCommunity/issues/1288

## 動作確認手順(Step for Confirmation)

- [x] Confirm on Unity 2019.3.14f1
- [x] Confirm on Unity 2021.2.3f1
