### PR TITLE
Fix bug openRate in case app was stopped

### DIFF
--- a/ncmb_unity/Assets/NCMB/NCMBManager.cs
+++ b/ncmb_unity/Assets/NCMB/NCMBManager.cs
@@ -41,6 +41,7 @@ namespace NCMB
 	public class NCMBManager : MonoBehaviour
 	{
 
+		const string openedPushIdKey = "OpenedPushIdKey";
 		public virtual void Awake ()
 		{
 			if (!NCMBSettings._isInitialized) {
@@ -119,6 +120,17 @@ namespace NCMB
 
 		#region Process notification for iOS only
 
+		#if UNITY_ANDROID
+		void Update ()
+		{
+			if (PlayerPrefs.HasKey(openedPushIdKey)){
+				string pushId = PlayerPrefs.GetString(openedPushIdKey);
+				NCMBAnalytics.TrackAppOpened (pushId);
+				PlayerPrefs.DeleteKey(openedPushIdKey);
+			}
+		}
+		#endif
+
 		#if UNITY_IOS
 		void Start ()
 		{
@@ -127,6 +139,12 @@ namespace NCMB
 
 		void Update ()
 		{
+			if (PlayerPrefs.HasKey(openedPushIdKey)){
+				string pushId = PlayerPrefs.GetString(openedPushIdKey);
+				NCMBAnalytics.TrackAppOpened (pushId);
+				PlayerPrefs.DeleteKey(openedPushIdKey);
+			}
+
 			if (UnityEngine.iOS.NotificationServices.remoteNotificationCount > 0) {
 				ProcessNotification ();
 				NCMBPush push = new NCMBPush ();
@@ -349,7 +367,7 @@ namespace NCMB
 		//ネイティブからプッシュIDを受け取り開封通知
 		private void onAnalyticsReceived (string _pushId)
 		{
-			NCMBAnalytics.TrackAppOpened (_pushId);
+			PlayerPrefs.SetString(openedPushIdKey, _pushId);
 		}
 
 		//installation情報を削除

--- a/ncmb_unity/Assets/Plugins/iOS/NCMBAppControllerPushAdditions.mm
+++ b/ncmb_unity/Assets/Plugins/iOS/NCMBAppControllerPushAdditions.mm
@@ -326,7 +326,6 @@ extern "C"
         NCMBPushHandle(notificationInfo);
     } else {
         appStartFromNofTap = true;
-        NSLog(@"[NCMB]: Set appStartFromNofTap=true");
         //Delay for 10 miliseconds
         [self performSelector:@selector(handleRichPushIfReady:) withObject:userInfo afterDelay:0.01];
     }


### PR DESCRIPTION
## 概要(Summary)

- Fixed #227 

## 動作確認手順(Step for Confirmation)

- Run the unit test (Unity 2020.3.7f1)
- Testing

| OS | アプリ状況 | 開封通知登録動作 |
| --------------- | --------------- | --------------- |
| iOS | フォーグランド | Skip this case - By default App not show alert when app in foreground|
| iOS | バックグランド | OK |
| iOS | 停止中 | OK |
| iOS | リッチプッシュ通知 | OK |
| Android| フォーグランド | OK |
| Android| バックグランド | OK |
| Android| 停止中 | OK|
| Android | リッチプッシュ通知 | OK |

## テスト環境(Testing environment)
  - Unity 2019.4.40f1, 2020.3.7f1, 2021.3.5f1
  -  Android Studio Arctic Fox | 2020.3.1 Patch 3
  - Android 9/Android 12
  - Xcode 13.4.1 (13F100)
  - iPhone X (15.0.2)