### PR TITLE
Fix bug openRate in case app was stopped: save openedPushId to local using File

### DIFF
--- a/ncmb_unity/Assets/NCMB/NCMBManager.cs
+++ b/ncmb_unity/Assets/NCMB/NCMBManager.cs
@@ -365,6 +365,8 @@ namespace NCMB
 			return text;
 		}
 
+		// ディスク入出力関数
+		// 書き込み
 		private void SaveOpenedPushId(string pushId)
 		{
 			try
@@ -387,6 +389,7 @@ namespace NCMB
 			}
 		}
 
+		// 読み込み
 		private string LoadOpenedPushId() {
 			try
 			{

--- a/ncmb_unity/Assets/NCMB/NCMBManager.cs
+++ b/ncmb_unity/Assets/NCMB/NCMBManager.cs
@@ -118,8 +118,6 @@ namespace NCMB
 
 		#endregion
 
-		#region Process notification for iOS only
-
 		#if UNITY_ANDROID
 		void Update ()
 		{
@@ -130,6 +128,8 @@ namespace NCMB
 			}
 		}
 		#endif
+
+		#region Process notification for iOS only
 
 		#if UNITY_IOS
 		void Start ()
@@ -368,7 +368,7 @@ namespace NCMB
 		private void SaveOpenedPushId(string pushId)
 		{
 			try
-        	{
+			{
 				if (pushId == null || pushId == "") {
 					if (File.Exists(Application.persistentDataPath + fileName)) {
 						File.Delete(Application.persistentDataPath + fileName);
@@ -382,11 +382,14 @@ namespace NCMB
 						writer.Write(pushId);
 					}
 				}
-			} catch (Exception e){}
+			} catch (Exception e){
+				NCMBDebug.Log ("File save error!【Message】:" + e.Message);
+			}
 		}
+
 		private string LoadOpenedPushId() {
 			try
-        	{
+			{
 				if (File.Exists(Application.persistentDataPath + fileName))
 				{
 					string pushId;
@@ -399,9 +402,12 @@ namespace NCMB
 					}
 					return pushId;
 				}
-			} catch (Exception e){}
-			return "";
+			} catch (Exception e){
+				NCMBDebug.Log ("File read error!【Message】:" + e.Message);
+			}
+			return null;
 		}
+
 		//ネイティブからプッシュIDを受け取り開封通知
 		private void onAnalyticsReceived (string _pushId)
 		{

--- a/ncmb_unity/Assets/Plugins/iOS/NCMBAppControllerPushAdditions.mm
+++ b/ncmb_unity/Assets/Plugins/iOS/NCMBAppControllerPushAdditions.mm
@@ -326,7 +326,6 @@ extern "C"
         NCMBPushHandle(notificationInfo);
     } else {
         appStartFromNofTap = true;
-        NSLog(@"[NCMB]: Set appStartFromNofTap=true");
         //Delay for 10 miliseconds
         [self performSelector:@selector(handleRichPushIfReady:) withObject:userInfo afterDelay:0.01];
     }


### PR DESCRIPTION
## 概要(Summary)

- Fixed #227 

## 動作確認手順(Step for Confirmation)

- Run the unit test (Unity 2020.3.7f1)
- Testing

| OS | アプリ状況 | 開封通知登録動作 |
| --------------- | --------------- | --------------- |
| iOS | フォーグランド | Skip this case - By default App not show alert when app in foreground|
| iOS | バックグランド | OK |
| iOS | 停止中 | OK |
| iOS | リッチプッシュ通知 | OK |
| Android| フォーグランド | OK |
| Android| バックグランド | OK |
| Android| 停止中 | OK|
| Android | リッチプッシュ通知 | OK |

## テスト環境(Testing environment)
  - Unity 2019.4.40f1, 2020.3.7f1, 2021.3.5f1
  -  Android Studio Arctic Fox | 2020.3.1 Patch 3
  - Android 9/Android 12
  - Xcode 13.4.1 (13F100)
  - iPhone X (15.0.2)