### PR TITLE
Upgrade project ncmb_unity to Unity 2021.3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ obj/
 *.user
 *.unityproj
 *.booproj
+*.meta
 
 ============
 OS generated

--- a/ncmb_unity/Assets/NCMB/Script/NCMBConnection.cs
+++ b/ncmb_unity/Assets/NCMB/Script/NCMBConnection.cs
@@ -466,6 +466,8 @@ namespace NCMB.Internal
 				}
 			}
 
+			req.Dispose();
+
 		}
 	}
 }

--- a/ncmb_unity/Assets/PlayModeTest/NCMBScriptTest.cs
+++ b/ncmb_unity/Assets/PlayModeTest/NCMBScriptTest.cs
@@ -150,16 +150,14 @@ public class NCMBScriptTest
      * - 内容：スクリプト実行APIメソッド(DELETE)で正常に処理されるか確認する
      * - 結果：エラーが発生しないこと
      */
+
 	[UnityTest]
 	public IEnumerator ExecuteCallbackWhenExecuteScriptTest_DELETE ()
 	{
 		NCMBScript script = new NCMBScript ("testScript_DELETE.js", NCMBScript.MethodType.DELETE, _endPoint);
 		script.ExecuteAsync (null, null, null, (byte[] result, NCMBException e) => {
 			if (e == null) {
-				// string cmd = System.Text.Encoding.UTF8.GetString (result);
-				// cmd = cmd.TrimEnd ('\0');//終端文字の削除
-				Assert.IsEmpty(result);
-				// Assert.AreEqual ("", cmd);
+				Assert.Null(result);
 			} else {
 				Assert.Fail (e.ErrorMessage);
 			}
@@ -169,6 +167,7 @@ public class NCMBScriptTest
 		yield return NCMBTestSettings.AwaitAsync ();
 		Assert.True (NCMBTestSettings.CallbackFlag);
 	}
+
 
 	/**
      * - 内容：スクリプト実行APIメソッドでエラーが返却された際に正常に処理されるか確認する

--- a/ncmb_unity/Assets/PlayModeTest/YamlDotNet/Serialization/YamlAttributeOverrides.cs
+++ b/ncmb_unity/Assets/PlayModeTest/YamlDotNet/Serialization/YamlAttributeOverrides.cs
@@ -54,7 +54,7 @@ namespace YamlDotNet.Serialization
 
             public override int GetHashCode()
             {
-                return HashCode.CombineHashCodes(AttributeType.GetHashCode(), PropertyName.GetHashCode());
+                return YamlDotNet.Core.HashCode.CombineHashCodes(AttributeType.GetHashCode(), PropertyName.GetHashCode());
             }
         }
 
@@ -79,7 +79,7 @@ namespace YamlDotNet.Serialization
 
             public override int GetHashCode()
             {
-                return HashCode.CombineHashCodes(RegisteredType.GetHashCode(), Attribute.GetHashCode());
+                return YamlDotNet.Core.HashCode.CombineHashCodes(RegisteredType.GetHashCode(), Attribute.GetHashCode());
             }
 
             /// <summary>

--- a/ncmb_unity/Packages/manifest.json
+++ b/ncmb_unity/Packages/manifest.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.9",
-    "com.unity.ide.visualstudio": "2.0.14",
-    "com.unity.ide.vscode": "1.2.4",
-    "com.unity.nuget.newtonsoft-json": "2.0.2",
-    "com.unity.test-framework": "1.1.29",
-    "com.unity.timeline": "1.6.3",
+    "com.unity.ide.rider": "3.0.15",
+    "com.unity.ide.visualstudio": "2.0.16",
+    "com.unity.ide.vscode": "1.2.5",
+    "com.unity.nuget.newtonsoft-json": "3.0.2",
+    "com.unity.test-framework": "1.1.31",
+    "com.unity.timeline": "1.6.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/ncmb_unity/Packages/packages-lock.json
+++ b/ncmb_unity/Packages/packages-lock.json
@@ -14,7 +14,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.9",
+      "version": "3.0.15",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -23,7 +23,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.14",
+      "version": "2.0.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -32,21 +32,21 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.vscode": {
-      "version": "1.2.4",
+      "version": "1.2.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.newtonsoft-json": {
-      "version": "2.0.2",
+      "version": "3.0.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.29",
+      "version": "1.1.31",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -57,7 +57,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.timeline": {
-      "version": "1.6.3",
+      "version": "1.6.4",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ncmb_unity/ProjectSettings/ProjectVersion.txt
+++ b/ncmb_unity/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.30f1
-m_EditorVersionWithRevision: 2020.3.30f1 (1fb1bf06830e)
+m_EditorVersion: 2021.3.9f1
+m_EditorVersionWithRevision: 2021.3.9f1 (ad3870b89536)

--- a/ncmb_unity/UserSettings/EditorUserSettings.asset
+++ b/ncmb_unity/UserSettings/EditorUserSettings.asset
@@ -6,10 +6,10 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedSceneGuid-0:
-      value: 500103545050595a085a0d7744770c43471541287a7c2764752b4864bbb06469
+      value: 5507575e00030c585d5c5a704977084443154c7c2f2d72672b7f4b60e3e4656e
       flags: 0
     RecentlyUsedSceneGuid-1:
-      value: 5507575e00030c585d5c5a704977084443154c7c2f2d72672b7f4b60e3e4656e
+      value: 500103545050595a085a0d7744770c43471541287a7c2764752b4864bbb06469
       flags: 0
     RecentlyUsedScenePath-0:
       value: 5507575e00030c585d5c5a704977084443154c7c2f2d72672b7f4b60e3e4656e


### PR DESCRIPTION
## 概要(Summary)

- ncmb_unityプロジェクトをUnity 2021版を対応するために更新します

## 動作確認手順(Step for Confirmation)

- 環境：Unity 2021.3.9f1
- Unitテスト実施：〇
 ![image](https://user-images.githubusercontent.com/8982421/201614688-b16e4cc6-4fd9-427c-93e9-5f267c146c2f.png)